### PR TITLE
Initialize basic Flutter to-do list project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
-# to_do_list_app
+# To Do List App
+
+This is a simple Flutter-based to do list application. The project is organized into models, screens, widgets, services, and utilities. A basic test suite is provided in the `test` directory.
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'screens/home_page.dart';
+
+void main() => runApp(const ToDoListApp());
+
+class ToDoListApp extends StatelessWidget {
+  const ToDoListApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      title: 'To Do List',
+      home: HomePage(),
+    );
+  }
+}
+

--- a/lib/models/task.dart
+++ b/lib/models/task.dart
@@ -1,0 +1,7 @@
+class Task {
+  final String title;
+  bool completed;
+
+  Task({required this.title, this.completed = false});
+}
+

--- a/lib/models/todo_list.dart
+++ b/lib/models/todo_list.dart
@@ -1,0 +1,9 @@
+import 'task.dart';
+
+class TodoList {
+  final String name;
+  final List<Task> tasks;
+
+  TodoList({required this.name, this.tasks = const []});
+}
+

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class HomePage extends StatelessWidget {
+  const HomePage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('To Do Lists')),
+      body: const Center(child: Text('Home Page')),
+    );
+  }
+}
+

--- a/lib/screens/list_detail_page.dart
+++ b/lib/screens/list_detail_page.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+class ListDetailPage extends StatelessWidget {
+  final String listName;
+
+  const ListDetailPage({Key? key, required this.listName}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(listName)),
+      body: const Center(child: Text('List Details')),
+    );
+  }
+}
+

--- a/lib/screens/login_page.dart
+++ b/lib/screens/login_page.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class LoginPage extends StatelessWidget {
+  const LoginPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Login')),
+      body: const Center(child: Text('Login Page')),
+    );
+  }
+}
+

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,0 +1,8 @@
+class AuthService {
+  Future<bool> login(String username, String password) async {
+    // TODO: implement real authentication
+    await Future.delayed(const Duration(milliseconds: 500));
+    return username.isNotEmpty && password.isNotEmpty;
+  }
+}
+

--- a/lib/services/sync_service.dart
+++ b/lib/services/sync_service.dart
@@ -1,0 +1,7 @@
+class SyncService {
+  Future<void> sync() async {
+    // TODO: implement sync logic
+    await Future.delayed(const Duration(milliseconds: 500));
+  }
+}
+

--- a/lib/utils/validators.dart
+++ b/lib/utils/validators.dart
@@ -1,0 +1,9 @@
+class Validators {
+  static String? nonEmpty(String? value) {
+    if (value == null || value.trim().isEmpty) {
+      return 'Field cannot be empty';
+    }
+    return null;
+  }
+}
+

--- a/lib/widgets/add_edit_dialogs.dart
+++ b/lib/widgets/add_edit_dialogs.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+Future<String?> showAddDialog(BuildContext context) {
+  final controller = TextEditingController();
+  return showDialog<String>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: const Text('Add Item'),
+      content: TextField(controller: controller),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.pop(context, controller.text),
+          child: const Text('Add'),
+        ),
+      ],
+    ),
+  );
+}
+

--- a/lib/widgets/task_tile.dart
+++ b/lib/widgets/task_tile.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import '../models/task.dart';
+
+class TaskTile extends StatelessWidget {
+  final Task task;
+  final ValueChanged<bool?>? onChanged;
+
+  const TaskTile({Key? key, required this.task, this.onChanged}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return CheckboxListTile(
+      title: Text(task.title),
+      value: task.completed,
+      onChanged: onChanged,
+    );
+  }
+}
+

--- a/lib/widgets/todo_list_tile.dart
+++ b/lib/widgets/todo_list_tile.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class TodoListTile extends StatelessWidget {
+  final String title;
+  final VoidCallback? onTap;
+
+  const TodoListTile({Key? key, required this.title, this.onTap}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(title),
+      trailing: const Icon(Icons.chevron_right),
+      onTap: onTap,
+    );
+  }
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,13 @@
+name: to_do_list_app
+description: A simple to do list application.
+version: 0.1.0
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true
+

--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -1,0 +1,8 @@
+import 'package:test/test.dart';
+
+void main() {
+  test('dummy test', () {
+    expect(1 + 1, equals(2));
+  });
+}
+


### PR DESCRIPTION
## Summary
- set up README with project overview
- add Flutter pubspec
- implement skeleton app with models, screens, widgets, services, utils
- add a placeholder test

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686da74c45d4832696c11805908d1b27