### PR TITLE
Add light and dark themes

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,12 +6,28 @@ void main() => runApp(const ToDoListApp());
 class ToDoListApp extends StatelessWidget {
   const ToDoListApp({Key? key}) : super(key: key);
 
+  ThemeData _buildLightTheme() {
+    return ThemeData(
+      brightness: Brightness.light,
+      primarySwatch: Colors.blue,
+    );
+  }
+
+  ThemeData _buildDarkTheme() {
+    return ThemeData(
+      brightness: Brightness.dark,
+      primarySwatch: Colors.blue,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
+    return MaterialApp(
       title: 'To Do List',
-      home: HomePage(),
+      theme: _buildLightTheme(),
+      darkTheme: _buildDarkTheme(),
+      themeMode: ThemeMode.system,
+      home: const HomePage(),
     );
   }
 }
-


### PR DESCRIPTION
## Summary
- add theme support to `lib/main.dart`

## Testing
- `dart format -o none --set-exit-if-changed lib/main.dart` *(fails: command not found)*
- `dart pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686da822dfec8326b2ccf0bb5f623d9c