### PR TITLE
Add TodoList model with JSON

### DIFF
--- a/lib/models/todo_list.dart
+++ b/lib/models/todo_list.dart
@@ -1,9 +1,33 @@
 import 'task.dart';
 
 class TodoList {
+  final String id;
   final String name;
   final List<Task> tasks;
 
-  TodoList({required this.name, this.tasks = const []});
+  TodoList({required this.id, required this.name, this.tasks = const []});
+
+  factory TodoList.fromJson(Map<String, dynamic> json) {
+    return TodoList(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      tasks: json['tasks'] != null
+          ? (json['tasks'] as List)
+              .map((task) => Task(
+                    title: task['title'] as String,
+                    completed: task['completed'] ?? false,
+                  ))
+              .toList()
+          : <Task>[],
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'tasks': tasks
+            .map((task) => {'title': task.title, 'completed': task.completed})
+            .toList(),
+      };
 }
 


### PR DESCRIPTION
## Summary
- expand TodoList model to include `id`
- add serialization helpers for TodoList

## Testing
- `dart test` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686da83d266483268f8908484ca42928