### PR TITLE
Implement Firestore sync service

### DIFF
--- a/lib/services/sync_service.dart
+++ b/lib/services/sync_service.dart
@@ -1,7 +1,84 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../models/todo_list.dart';
+import '../models/task.dart';
+
+/// Service that synchronizes todo lists and tasks with Firebase Cloud Firestore.
+///
+/// The service exposes streams for real-time updates and persists data locally
+/// using Firestore's built-in offline capabilities.
 class SyncService {
-  Future<void> sync() async {
-    // TODO: implement sync logic
-    await Future.delayed(const Duration(milliseconds: 500));
+  final FirebaseFirestore _firestore;
+
+  SyncService({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance {
+    _firestore.settings = const Settings(persistenceEnabled: true);
+  }
+
+  /// Watches all todo lists in Firestore.
+  Stream<List<TodoList>> watchTodoLists() {
+    return _firestore.collection('todoLists').snapshots().map((snapshot) {
+      return snapshot.docs.map((doc) {
+        final data = doc.data();
+        return TodoList(name: data['name'] as String);
+      }).toList();
+    });
+  }
+
+  /// Adds a new todo list to Firestore.
+  Future<DocumentReference> addTodoList(TodoList list) async {
+    return _firestore.collection('todoLists').add({'name': list.name});
+  }
+
+  /// Updates an existing todo list document.
+  Future<void> updateTodoList(String id, TodoList list) async {
+    await _firestore.collection('todoLists').doc(id).set({'name': list.name});
+  }
+
+  /// Deletes a todo list from Firestore.
+  Future<void> deleteTodoList(String id) async {
+    await _firestore.collection('todoLists').doc(id).delete();
+  }
+
+  /// Watches tasks of a specific todo list document.
+  Stream<List<Task>> watchTasks(String listId) {
+    return _firestore
+        .collection('todoLists')
+        .doc(listId)
+        .collection('tasks')
+        .snapshots()
+        .map((snapshot) => snapshot.docs
+            .map((doc) => Task(
+                  title: doc['title'] as String,
+                  completed: doc['completed'] as bool? ?? false,
+                ))
+            .toList());
+  }
+
+  /// Adds a task to the given todo list.
+  Future<DocumentReference> addTask(String listId, Task task) async {
+    return _firestore.collection('todoLists').doc(listId).collection('tasks').add({
+      'title': task.title,
+      'completed': task.completed,
+    });
+  }
+
+  /// Updates an existing task document.
+  Future<void> updateTask(String listId, String taskId, Task task) async {
+    await _firestore
+        .collection('todoLists')
+        .doc(listId)
+        .collection('tasks')
+        .doc(taskId)
+        .set({'title': task.title, 'completed': task.completed});
+  }
+
+  /// Deletes a task from a todo list.
+  Future<void> deleteTask(String listId, String taskId) async {
+    await _firestore
+        .collection('todoLists')
+        .doc(listId)
+        .collection('tasks')
+        .doc(taskId)
+        .delete();
   }
 }
-

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  firebase_core: ^1.0.0
+  cloud_firestore: ^2.5.4
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- add Firebase Cloud Firestore sync logic in `SyncService`
- enable offline persistence and real-time updates
- add `firebase_core` and `cloud_firestore` dependencies

## Testing
- `dart test` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686da87cd78c8326a23651ffaf29a02e