### PR TITLE
Add TaskTile with due date support

### DIFF
--- a/lib/models/task.dart
+++ b/lib/models/task.dart
@@ -1,7 +1,12 @@
 class Task {
   final String title;
+  final DateTime? dueDate;
   bool completed;
 
-  Task({required this.title, this.completed = false});
+  Task({
+    required this.title,
+    this.dueDate,
+    this.completed = false,
+  });
 }
 

--- a/lib/widgets/task_tile.dart
+++ b/lib/widgets/task_tile.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
 import '../models/task.dart';
 
 class TaskTile extends StatelessWidget {
@@ -9,8 +11,13 @@ class TaskTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final dueText = task.dueDate != null
+        ? DateFormat.yMMMd().format(task.dueDate!)
+        : null;
+
     return CheckboxListTile(
       title: Text(task.title),
+      subtitle: dueText != null ? Text('Due: $dueText') : null,
       value: task.completed,
       onChanged: onChanged,
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  intl: ^0.18.0
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- extend `Task` model with optional `dueDate`
- add `intl` package for date formatting
- update `TaskTile` to show title, due date, and completion status

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686da860f49083268c693c5b0c930462