### PR TITLE
Add TodoListTile widget

### DIFF
--- a/lib/widgets/todo_list_tile.dart
+++ b/lib/widgets/todo_list_tile.dart
@@ -1,15 +1,29 @@
 import 'package:flutter/material.dart';
+import '../models/todo_list.dart';
 
+/// A list tile that displays a [TodoList] with the number of incomplete tasks.
 class TodoListTile extends StatelessWidget {
-  final String title;
+  /// The to do list to display.
+  final TodoList todoList;
+
+  /// Callback when the tile is tapped.
   final VoidCallback? onTap;
 
-  const TodoListTile({Key? key, required this.title, this.onTap}) : super(key: key);
+  const TodoListTile({Key? key, required this.todoList, this.onTap})
+      : super(key: key);
+
+  /// Returns the number of tasks in [todoList] that are not completed yet.
+  int get _remainingTasks =>
+      todoList.tasks.where((t) => !t.completed).length;
 
   @override
   Widget build(BuildContext context) {
+    final remaining = _remainingTasks;
+    final subtitle = '$remaining incomplete task${remaining == 1 ? '' : 's'}';
+
     return ListTile(
-      title: Text(title),
+      title: Text(todoList.name),
+      subtitle: Text(subtitle),
       trailing: const Icon(Icons.chevron_right),
       onTap: onTap,
     );


### PR DESCRIPTION
## Summary
- add a reusable TodoListTile widget

## Testing
- `dart test` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686da858247083269fe0ed1102dd0968