### PR TITLE
Implement Firebase login/register

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,12 @@
 import 'package:flutter/material.dart';
-import 'screens/home_page.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'screens/login_page.dart';
 
-void main() => runApp(const ToDoListApp());
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp();
+  runApp(const ToDoListApp());
+}
 
 class ToDoListApp extends StatelessWidget {
   const ToDoListApp({Key? key}) : super(key: key);
@@ -10,7 +15,7 @@ class ToDoListApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return const MaterialApp(
       title: 'To Do List',
-      home: HomePage(),
+      home: LoginPage(),
     );
   }
 }

--- a/lib/screens/login_page.dart
+++ b/lib/screens/login_page.dart
@@ -1,13 +1,85 @@
 import 'package:flutter/material.dart';
+import '../services/auth_service.dart';
+import '../utils/validators.dart';
+import 'home_page.dart';
 
-class LoginPage extends StatelessWidget {
+class LoginPage extends StatefulWidget {
   const LoginPage({Key? key}) : super(key: key);
+
+  @override
+  State<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends State<LoginPage> {
+  final _formKey = GlobalKey<FormState>();
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  final AuthService _authService = AuthService();
+  bool _isLogin = true;
+  bool _loading = false;
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+    setState(() => _loading = true);
+    try {
+      if (_isLogin) {
+        await _authService
+            .login(_emailController.text, _passwordController.text);
+      } else {
+        await _authService
+            .register(_emailController.text, _passwordController.text);
+      }
+      if (!mounted) return;
+      Navigator.of(context).pushReplacement(
+          MaterialPageRoute(builder: (_) => const HomePage()));
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(e.toString())));
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Login')),
-      body: const Center(child: Text('Login Page')),
+      appBar: AppBar(title: Text(_isLogin ? 'Login' : 'Register')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              TextFormField(
+                controller: _emailController,
+                decoration: const InputDecoration(labelText: 'Email'),
+                validator: Validators.nonEmpty,
+              ),
+              TextFormField(
+                controller: _passwordController,
+                decoration: const InputDecoration(labelText: 'Password'),
+                obscureText: true,
+                validator: Validators.nonEmpty,
+              ),
+              const SizedBox(height: 20),
+              _loading
+                  ? const CircularProgressIndicator()
+                  : ElevatedButton(
+                      onPressed: _submit,
+                      child: Text(_isLogin ? 'Login' : 'Register'),
+                    ),
+              TextButton(
+                onPressed: () => setState(() => _isLogin = !_isLogin),
+                child: Text(_isLogin
+                    ? 'Need an account? Register'
+                    : 'Have an account? Login'),
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,8 +1,22 @@
+import 'package:firebase_auth/firebase_auth.dart';
+
 class AuthService {
-  Future<bool> login(String username, String password) async {
-    // TODO: implement real authentication
-    await Future.delayed(const Duration(milliseconds: 500));
-    return username.isNotEmpty && password.isNotEmpty;
+  final FirebaseAuth _auth = FirebaseAuth.instance;
+
+  Future<UserCredential> login(String email, String password) async {
+    return _auth.signInWithEmailAndPassword(
+        email: email, password: password);
   }
+
+  Future<UserCredential> register(String email, String password) async {
+    return _auth.createUserWithEmailAndPassword(
+        email: email, password: password);
+  }
+
+  Future<void> logout() async {
+    await _auth.signOut();
+  }
+
+  Stream<User?> get userChanges => _auth.userChanges();
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  firebase_core: ^2.24.0
+  firebase_auth: ^4.6.1
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- enable Firebase initialization and login page in main app
- implement AuthService for Firebase Auth email/password
- create login and registration UI with form validation
- add Firebase dependencies

## Testing
- `flutter pub get` *(fails: command not found)*
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686da8745d2883268e2be6a6b1c2d0b3